### PR TITLE
[RISE-3151] - Fix CircleCI package-lambdas job path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
       - setup-zip
       - run: dotnet tool install --local --create-manifest-if-needed Amazon.Lambda.Tools
       # Package Lambda
-      - run: dotnet lambda package -pl CategoryMigrationLambda/CategoryMigrationLambda -o lambda-packages/category-migration-lambda.zip
+      - run: dotnet lambda package -pl CategoryMigrationLambda -o lambda-packages/category-migration-lambda.zip
       - persist_to_workspace:
           root: lambda-packages
           paths:


### PR DESCRIPTION
- Fix project path from CategoryMigrationLambda/CategoryMigrationLambda to CategoryMigrationLambda
- The correct path is the directory containing the .csproj file
- This resolves the 'Provided project location is not a directory' error