### PR TITLE
[RISE-3151] - Fix terraform resource conflicts by using unique names

### DIFF
--- a/terraform/workspace/lambdas.tf
+++ b/terraform/workspace/lambdas.tf
@@ -5,7 +5,7 @@
 module "category_migration_lambda" {
   source = "./modules/lambda"
 
-  lambda_name = "lambda"
+  lambda_name = "lambda-v2"
   handler     = "CategoryMigrationLambda::CategoryMigrationLambda.Function::FunctionHandler"
   runtime     = "dotnet8"
   timeout     = 900


### PR DESCRIPTION
- Change lambda_name from 'lambda' to 'lambda-v2' to avoid conflicts
- This creates unique resource names: category-migration-lambda-v2
- Resolves 'ResourceAlreadyExistsException' errors for:
  - CloudWatch Log Group
  - IAM Role
- Terraform plan now runs successfully without conflicts