### PR TITLE
[RISE-3151] - Fix CircleCI deploy-lambdas function name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - setup-aws
       - aws-cli/install
       # Deploy Lambda
-      - run: aws lambda update-function-code --function-name category-migration-lambda --zip-file fileb://lambda-packages/category-migration-lambda.zip
+      - run: aws lambda update-function-code --function-name category-migration-lambda-v2 --zip-file fileb://lambda-packages/category-migration-lambda.zip
       - when:
           condition:
             equal: [prod, <<parameters.environment>>]


### PR DESCRIPTION
- Update deploy-lambdas job to use category-migration-lambda-v2 function name
- This matches the terraform configuration change
- Resolves Lambda runtime error by deploying actual .NET code instead of placeholder